### PR TITLE
Improve traceback messages

### DIFF
--- a/widget_code_input/utils.py
+++ b/widget_code_input/utils.py
@@ -1,6 +1,14 @@
 import ast
+import sys
+import traceback
 
-# from xml.sax.saxutils import escape
+
+class CodeValidationError(Exception):
+    """Class raised when there is an exception within a WidgetCodeInput."""
+
+    def __init__(self, msg, orig_exc):
+        super().__init__(msg)
+        self.orig_exc = orig_exc
 
 
 def is_valid_variable_name(name):
@@ -76,38 +84,44 @@ def build_signature(function_name, function_parameters):
     return "def {}({}):".format(function_name, function_parameters)
 
 
-# def build_function_signature(function_name, args, defaults=None, varargs=None, keywords=None):
-#     """
-#     For the following function:
+def format_syntax_error_msg(exc):
+    """
+    Return a string reproducing the output of a SyntaxError.
 
-#     def fn(a, b, c=1, d="a", *args):
-#         pass
+    :param exc: The exception that is being processed.
+    """
+    se_args = exc.args[1]
+    return f"""SyntaxError in code input: {exc.args[0]}
+File "{se_args[0]}", line {se_args[1]}
+{se_args[3]}{' ' * max(0, se_args[2] - 1)}^
+"""
 
-#     we have:
 
-#     - function_name = "fn"
-#     - args = ['a', 'b', 'c', 'd']
-#     - defaults = [1, 'a']
-#     - varargs = 'args'
-#     - keywords = None
+def format_generic_error_msg(exc, code_widget):
+    """
+    Return a string reproducing the traceback of a typical error.
+    This includes line numbers, as well as neighboring lines.
 
-#     For now, defaults are not implemented (they require e.g. to convert a string to its python representation with quotes)
-#     """
-#     assert is_valid_variable_name(function_name)
-#     for arg in args:
-#         assert is_valid_variable_name(function_name)
-#     if varargs is not None:
-#         assert is_valid_variable_name(varargs)
-#     if keywords is not None:
-#         assert is_valid_variable_name(keywords)
+    It will require also the code_widget instance, to get the actual source code.
 
-#     mangled_args = [arg for arg in args] # here one could put the logic for defaults as well
-#     if varargs is not None:
-#         mangled_args.append('*{}'.format(varargs))
-#     if keywords is not None:
-#         mangled_args.append('*{}'.format(keywords))
+    :note: this must be called from withou the exception, as it will get the current traceback state.
 
-#     args_string = ", ".join(args)
+    :param exc: The exception that is being processed.
+    :param code_widget: the instance of the code widget with the code that raised the exception.
+    """
+    error_class, _, tb = sys.exc_info()
+    line_number = traceback.extract_tb(tb)[-1][1]
+    code_lines = code_widget.full_function_code.splitlines()
 
-#     signature="def {}({}):".format(function_name, args_string)
-#     return signature
+    err_msg = f"{error_class.__name__} in code input: {str(exc)}\n"
+    if line_number > 2:
+        err_msg += f"     {line_number - 2:4d} {code_lines[line_number - 3]}\n"
+    if line_number > 1:
+        err_msg += f"     {line_number - 1:4d} {code_lines[line_number - 2]}\n"
+    err_msg += f"---> {line_number:4d} {code_lines[line_number - 1]}\n"
+    if line_number < len(code_lines):
+        err_msg += f"     {line_number + 1:4d} {code_lines[line_number]}\n"
+    if line_number < len(code_lines) - 1:
+        err_msg += f"     {line_number + 2:4d} {code_lines[line_number + 1]}\n"
+
+    return err_msg


### PR DESCRIPTION
This PR adds code to improve the error messages and put more information on the location of the error.

# Examples of the new current behaviour

## No exception (same as before)
<img width="1070" alt="Screenshot 2022-06-28 at 12 39 03" src="https://user-images.githubusercontent.com/16132028/176165740-b9c3acad-c6d7-428d-9f96-9bf0208c56c3.png">

# SyntaxError
<img width="1065" alt="Screenshot 2022-06-28 at 12 39 18" src="https://user-images.githubusercontent.com/16132028/176165753-58a9a08e-129b-4fcf-9b2c-5bc76c61872a.png">

# NameError (or other exceptions during execution)
<img width="1069" alt="Screenshot 2022-06-28 at 12 39 27" src="https://user-images.githubusercontent.com/16132028/176165795-e9241d1c-e5de-4481-91af-c072e5819386.png">

Fixes #12.