### PR TITLE
Fix thrown exceptions is within functions in WCI

### DIFF
--- a/src/widget_code_input/utils.py
+++ b/src/widget_code_input/utils.py
@@ -104,13 +104,27 @@ def format_generic_error_msg(exc, code_widget):
 
     It will require also the code_widget instance, to get the actual source code.
 
-    :note: this must be called from withou the exception, as it will get the current traceback state.
+    :note: this must be called from without the exception, as it will get the current traceback state.
 
     :param exc: The exception that is being processed.
     :param code_widget: the instance of the code widget with the code that raised the exception.
     """
     error_class, _, tb = sys.exc_info()
-    line_number = traceback.extract_tb(tb)[-1][1]
+    frame_summaries = traceback.extract_tb(tb)
+    # The correct frame summary corresponding to wci not allways at the end
+    # therefore we loop through all of them
+    wci_frame_summary = None
+    for frame_summary in frame_summaries:
+        if frame_summary.filename == "widget_code_input":
+            wci_frame_summary = frame_summary
+    if wci_frame_summary is None:
+        warning.warn(
+                "Could not find traceback frame corresponding to "
+                "widget_code_input, we output whole error message."
+        )
+
+        return exc
+    line_number = wci_frame_summary[1]
     code_lines = code_widget.full_function_code.splitlines()
 
     err_msg = f"{error_class.__name__} in code input: {str(exc)}\n"


### PR DESCRIPTION
When an exception is thrown within a WCI, the last frame is used as context to add the input lines. This does not work if the exception is thrown within a function within WCI.  Therefore we now iterate through all traceback frames to find the one corresponding to WCI.

Still WIP, because the error message is reprinted completely, better to update the old one
Currently fix produces this
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File ~/code/scicode-widgets/.tox/tests-lab-3/lib/python3.11/site-packages/widget_code_input/__init__.py:168, in WidgetCodeInput.get_function_object.<locals>.catch_exceptions.<locals>.wrapper(*args, **kwargs)
    167 try:
--> 168     return func(*args, **kwargs)
    169 except Exception as exc:

File widget_code_input:9, in rtest(x)

File ~/code/scicode-widgets/.tox/tests-lab-3/lib/python3.11/site-packages/numpy/__init__.py:324, in __getattr__(attr)
    323 if attr in __former_attrs__:
--> 324     raise AttributeError(__former_attrs__[attr])
    326 if attr == 'testing':

AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

The above exception was the direct cause of the following exception:

CodeValidationError                       Traceback (most recent call last)
Cell In[3], line 1
----> 1 ex03_wci.run(5)

File ~/code/scicode-widgets/.tox/tests-lab-3/lib/python3.11/site-packages/scwidgets/code/_widget_code_input.py:87, in CodeInput.run(self, *args, **kwargs)
     86 def run(self, *args, **kwargs) -> Check.FunOutParamsT:
---> 87     return self.get_function_object()(*args, **kwargs)

File ~/code/scicode-widgets/.tox/tests-lab-3/lib/python3.11/site-packages/widget_code_input/__init__.py:171, in WidgetCodeInput.get_function_object.<locals>.catch_exceptions.<locals>.wrapper(*args, **kwargs)
    169 except Exception as exc:
    170     err_msg = format_generic_error_msg(exc, code_widget=self)
--> 171     raise CodeValidationError(err_msg, orig_exc=exc) from exc

CodeValidationError: AttributeError in code input: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
        7     # - try 5 and run and then change back to x then run, output does not vanish
        8     # - try "return np.float(x)", wci fails, error message does not vainsh
--->    9     np.array([5, str], dtype=np.float)
       10     return np.float(x)
```